### PR TITLE
Netstandard2.0

### DIFF
--- a/DummyServiceWorker/DummyServiceWorker.csproj
+++ b/DummyServiceWorker/DummyServiceWorker.csproj
@@ -10,8 +10,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="5.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
+		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
 		<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.14.0" />
 	</ItemGroup>
 

--- a/Tests/UnitTests.csproj
+++ b/Tests/UnitTests.csproj
@@ -9,7 +9,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
     <PackageReference Include="coverlet.collector" Version="3.1.0" />

--- a/TinyHealthCheck/HealthCheckService.cs
+++ b/TinyHealthCheck/HealthCheckService.cs
@@ -41,7 +41,7 @@ namespace TinyHealthCheck
                 while (!cancellationToken.IsCancellationRequested)
                 {
                     var httpContext = await _listener.GetContextAsync().ConfigureAwait(false);
-                    ThreadPool.QueueUserWorkItem(async x => await ProcessHealthCheck(x, cancellationToken).ConfigureAwait(false), httpContext, false);
+                    ThreadPool.QueueUserWorkItem(async x => await ProcessHealthCheck((HttpListenerContext)x, cancellationToken).ConfigureAwait(false), httpContext);
                 }
             }
             catch (Exception e)
@@ -80,7 +80,7 @@ namespace TinyHealthCheck
                 byte[] data = Encoding.UTF8.GetBytes(healthCheckResult.Body);
 
                 response.ContentLength64 = data.LongLength;
-                await response.OutputStream.WriteAsync(data, cancellationToken).ConfigureAwait(false);
+                await response.OutputStream.WriteAsync(data, 0, data.Length, cancellationToken).ConfigureAwait(false);
             }
         }
     }

--- a/TinyHealthCheck/Models/IHealthCheckResult.cs
+++ b/TinyHealthCheck/Models/IHealthCheckResult.cs
@@ -22,11 +22,11 @@ namespace TinyHealthCheck.Models
         /// <summary>
         /// The ContentType that the response will be returned as
         /// </summary>
-        public string ContentType { get; }
+        string ContentType { get; }
 
         /// <summary>
         /// The encoding of the response. The default(UTF8) should be fine except in special scenarios.
         /// </summary>
-        public Encoding ContentEncoding { get; }
+        Encoding ContentEncoding { get; }
     }
 }

--- a/TinyHealthCheck/TinyHealthCheck.csproj
+++ b/TinyHealthCheck/TinyHealthCheck.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <PackageProjectUrl>https://github.com/bruceharrison1984/TinyHealthCheck</PackageProjectUrl>
     <RepositoryUrl>https://github.com/bruceharrison1984/TinyHealthCheck</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
@@ -16,8 +16,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
+    <PackageReference Include="System.Text.Json" Version="6.0.4" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This PR makes this library compatible with the `netstandard2.0` feature set. This should allow many more people to make use of the library if they need it. The previous version was set for `net5.0` which isn't an LTS, so a large portion of people simply couldn't use this library.