### PR TITLE
Update to .NET 7

### DIFF
--- a/.github/workflows/devBuild.yml
+++ b/.github/workflows/devBuild.yml
@@ -13,6 +13,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
+    - name: Get Release Version
+      id: getReleaseVersion
+      run: echo ::set-output name=tag::${GITHUB_REF#refs/*/v}
+
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:

--- a/.github/workflows/devBuild.yml
+++ b/.github/workflows/devBuild.yml
@@ -2,27 +2,26 @@ name: Development Build
 
 on:
   push:
-    branches: [ '*' ]
+    branches: ["*"]
   workflow_dispatch:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 5.0.x
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 7.0.x
 
-    - name: Restore dependencies
-      run: dotnet restore
+      - name: Restore dependencies
+        run: dotnet restore
 
-    - name: Build
-      run: dotnet build --no-restore
+      - name: Build
+        run: dotnet build --no-restore
 
-    - name: Test
-      run: dotnet test --no-build --verbosity normal
+      - name: Test
+        run: dotnet test --no-build --verbosity normal

--- a/.github/workflows/devBuild.yml
+++ b/.github/workflows/devBuild.yml
@@ -17,6 +17,16 @@ jobs:
       id: getReleaseVersion
       run: echo ::set-output name=tag::${GITHUB_REF#refs/*/v}
 
+    - name: Get Release Version
+      id: getReleaseVersion-new
+      run: echo tag=${GITHUB_REF#refs/*/v} >> $GITHUB_OUTPUT
+
+    - name: Echo version
+      run: echo ${{ steps.getReleaseVersion.outputs.tag }}
+
+    - name: Echo version
+      run: echo ${{ steps.getReleaseVersion-new.outputs.tag }}
+
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:

--- a/.github/workflows/devBuild.yml
+++ b/.github/workflows/devBuild.yml
@@ -2,26 +2,27 @@ name: Development Build
 
 on:
   push:
-    branches: ["*"]
+    branches: [ '*' ]
   workflow_dispatch:
 
 jobs:
   build:
+
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: 7.0.x
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: 7.0.x
 
-      - name: Restore dependencies
-        run: dotnet restore
+    - name: Restore dependencies
+      run: dotnet restore
 
-      - name: Build
-        run: dotnet build --no-restore
+    - name: Build
+      run: dotnet build --no-restore
 
-      - name: Test
-        run: dotnet test --no-build --verbosity normal
+    - name: Test
+      run: dotnet test --no-build --verbosity normal

--- a/.github/workflows/devBuild.yml
+++ b/.github/workflows/devBuild.yml
@@ -13,20 +13,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Get Release Version
-      id: getReleaseVersion
-      run: echo ::set-output name=tag::${GITHUB_REF#refs/*/v}
-
-    - name: Get Release Version
-      id: getReleaseVersion-new
-      run: echo tag=${GITHUB_REF#refs/*/v} >> $GITHUB_OUTPUT
-
-    - name: Echo version
-      run: echo ${{ steps.getReleaseVersion.outputs.tag }}
-
-    - name: Echo version
-      run: echo ${{ steps.getReleaseVersion-new.outputs.tag }}
-
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:

--- a/.github/workflows/releaseBuild.yml
+++ b/.github/workflows/releaseBuild.yml
@@ -7,45 +7,45 @@ on:
 
 jobs:
   build:
+
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+    - uses: actions/checkout@v2
 
-      - name: Get Release Version
-        id: getReleaseVersion
-        run: echo ::set-output name=tag::${GITHUB_REF#refs/*/v}
+    - name: Get Release Version
+      id: getReleaseVersion
+      run: echo ::set-output name=tag::${GITHUB_REF#refs/*/v}
+    - name: Echo version
+      run: echo ${{ steps.getReleaseVersion.outputs.tag }}
 
-      - name: Echo version
-        run: echo ${{ steps.getReleaseVersion.outputs.tag }}
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 5.0.x
 
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: 7.0.x
+    - name: Restore dependencies
+      run: dotnet restore
 
-      - name: Restore dependencies
-        run: dotnet restore
+    - name: Build
+      run: dotnet build --no-restore
 
-      - name: Build
-        run: dotnet build --no-restore
+    - name: Test
+      run: dotnet test --no-build --verbosity normal
 
-      - name: Test
-        run: dotnet test --no-build --verbosity normal
+    - name: Package Nuget
+      run: dotnet pack -p:PackageVersion=${{ steps.getReleaseVersion.outputs.tag }} -o ./output
 
-      - name: Package Nuget
-        run: dotnet pack -p:PackageVersion=${{ steps.getReleaseVersion.outputs.tag }} -o ./output
+    - name: Push Nuget Package
+      run: dotnet nuget push ./output/TinyHealthCheck.${{ steps.getReleaseVersion.outputs.tag }}.nupkg --api-key ${{secrets.NUGET_TOKEN}} --source https://api.nuget.org/v3/index.json
 
-      - name: Push Nuget Package
-        run: dotnet nuget push ./output/TinyHealthCheck.${{ steps.getReleaseVersion.outputs.tag }}.nupkg --api-key ${{secrets.NUGET_TOKEN}} --source https://api.nuget.org/v3/index.json
+    ## Checkout so we can apply the new tag
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: "0"
 
-      ## Checkout so we can apply the new tag
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: "0"
-
-      ## Documentation: https://github.com/marvinpinto/action-automatic-releases
-      - uses: "marvinpinto/action-automatic-releases@latest"
-        with:
-          repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          prerelease: false
+    ## Documentation: https://github.com/marvinpinto/action-automatic-releases
+    - uses: "marvinpinto/action-automatic-releases@latest"
+      with:
+        repo_token: "${{ secrets.GITHUB_TOKEN }}"
+        prerelease: false

--- a/.github/workflows/releaseBuild.yml
+++ b/.github/workflows/releaseBuild.yml
@@ -15,7 +15,7 @@ jobs:
 
     - name: Get Release Version
       id: getReleaseVersion
-      run: echo ::set-output name=tag::${GITHUB_REF#refs/*/v}
+      run: echo tag=${GITHUB_REF#refs/*/v} >> $GITHUB_OUTPUT
 
     - name: Echo version
       run: echo ${{ steps.getReleaseVersion.outputs.tag }}

--- a/.github/workflows/releaseBuild.yml
+++ b/.github/workflows/releaseBuild.yml
@@ -11,18 +11,19 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Get Release Version
       id: getReleaseVersion
       run: echo ::set-output name=tag::${GITHUB_REF#refs/*/v}
+
     - name: Echo version
       run: echo ${{ steps.getReleaseVersion.outputs.tag }}
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 5.0.x
+        dotnet-version: 7.0.x
 
     - name: Restore dependencies
       run: dotnet restore
@@ -40,7 +41,7 @@ jobs:
       run: dotnet nuget push ./output/TinyHealthCheck.${{ steps.getReleaseVersion.outputs.tag }}.nupkg --api-key ${{secrets.NUGET_TOKEN}} --source https://api.nuget.org/v3/index.json
 
     ## Checkout so we can apply the new tag
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: "0"
 

--- a/.github/workflows/releaseBuild.yml
+++ b/.github/workflows/releaseBuild.yml
@@ -7,45 +7,44 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Get Release Version
-      id: getReleaseVersion
-      run: echo ::set-output name=tag::${GITHUB_REF#refs/*/v}
-    - name: Echo version
-      run: echo ${{ steps.getReleaseVersion.outputs.tag }}
+      - name: Get Release Version
+        id: getReleaseVersion
+        run: echo ::set-output name=tag::${GITHUB_REF#refs/*/v}
+      - name: Echo version
+        run: echo ${{ steps.getReleaseVersion.outputs.tag }}
 
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 5.0.x
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 7.0.x
 
-    - name: Restore dependencies
-      run: dotnet restore
+      - name: Restore dependencies
+        run: dotnet restore
 
-    - name: Build
-      run: dotnet build --no-restore
+      - name: Build
+        run: dotnet build --no-restore
 
-    - name: Test
-      run: dotnet test --no-build --verbosity normal
+      - name: Test
+        run: dotnet test --no-build --verbosity normal
 
-    - name: Package Nuget
-      run: dotnet pack -p:PackageVersion=${{ steps.getReleaseVersion.outputs.tag }} -o ./output
+      - name: Package Nuget
+        run: dotnet pack -p:PackageVersion=${{ steps.getReleaseVersion.outputs.tag }} -o ./output
 
-    - name: Push Nuget Package
-      run: dotnet nuget push ./output/TinyHealthCheck.${{ steps.getReleaseVersion.outputs.tag }}.nupkg --api-key ${{secrets.NUGET_TOKEN}} --source https://api.nuget.org/v3/index.json
+      - name: Push Nuget Package
+        run: dotnet nuget push ./output/TinyHealthCheck.${{ steps.getReleaseVersion.outputs.tag }}.nupkg --api-key ${{secrets.NUGET_TOKEN}} --source https://api.nuget.org/v3/index.json
 
-    ## Checkout so we can apply the new tag
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: "0"
+      ## Checkout so we can apply the new tag
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: "0"
 
-    ## Documentation: https://github.com/marvinpinto/action-automatic-releases
-    - uses: "marvinpinto/action-automatic-releases@latest"
-      with:
-        repo_token: "${{ secrets.GITHUB_TOKEN }}"
-        prerelease: false
+      ## Documentation: https://github.com/marvinpinto/action-automatic-releases
+      - uses: "marvinpinto/action-automatic-releases@latest"
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          prerelease: false

--- a/.github/workflows/releaseBuild.yml
+++ b/.github/workflows/releaseBuild.yml
@@ -15,6 +15,7 @@ jobs:
       - name: Get Release Version
         id: getReleaseVersion
         run: echo ::set-output name=tag::${GITHUB_REF#refs/*/v}
+
       - name: Echo version
         run: echo ${{ steps.getReleaseVersion.outputs.tag }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -348,3 +348,6 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+
+# .idea projects (rider)
+.idea/

--- a/DummyServiceWorker/Dockerfile
+++ b/DummyServiceWorker/Dockerfile
@@ -1,9 +1,9 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/runtime:5.0 AS base
+FROM mcr.microsoft.com/dotnet/runtime:7.0 AS base
 WORKDIR /app
 
-FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
 WORKDIR /src
 COPY ["DummyServiceWorker/DummyServiceWorker.csproj", "DummyServiceWorker/"]
 COPY ["TinyHealthCheck/TinyHealthCheck.csproj", "TinyHealthCheck/"]

--- a/DummyServiceWorker/DummyServiceWorker.csproj
+++ b/DummyServiceWorker/DummyServiceWorker.csproj
@@ -1,12 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk.Worker">
 
 	<PropertyGroup>
-		<TargetFramework>net5.0</TargetFramework>
+		<TargetFramework>net7.0</TargetFramework>
 		<UserSecretsId>dotnet-DummyServiceWorker-4B7A2D48-2FC8-47D3-85F2-3EC363843E8E</UserSecretsId>
 		<DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
 		<DockerLaunchAction>LaunchBrowser</DockerLaunchAction>
 		<DockerLaunchUrl>http://localhost:8080/healthz</DockerLaunchUrl>
 		<DockerfileRunArguments>-p 8080:8080 -p 8081:8081 -p 8082:8082</DockerfileRunArguments>
+		<LangVersion>11</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/DummyServiceWorker/DummyServiceWorker.csproj
+++ b/DummyServiceWorker/DummyServiceWorker.csproj
@@ -11,9 +11,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
-		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
-		<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.14.0" />
+		<PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
+		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0" />
+		<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.18.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ and utilizes a low priority thread pool for minimal impact on your service worke
   - This library creates endpoints without _any_ of the MVC packages
     - This means no middleware, auth, validation, etc
   - You can run different HealthChecks on different ports
+- Docker containers may have trouble using `localhost` for the hostname, it's reccomended to use `*` or `+` instead, [see this stackoverflow for more information](https://stackoverflow.com/questions/75961828/c-sharp-net-core-7-http-listener-app-wrapped-in-docker-cannot-be-reached-from)
 
 ## Simple Usage
 

--- a/Tests/UnitTests.csproj
+++ b/Tests/UnitTests.csproj
@@ -10,10 +10,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="NUnit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
-    <PackageReference Include="coverlet.collector" Version="3.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/UnitTests.csproj
+++ b/Tests/UnitTests.csproj
@@ -1,10 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>
+
+    <LangVersion>11</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TinyHealthCheck/Models/TinyHealthCheckConfig.cs
+++ b/TinyHealthCheck/Models/TinyHealthCheckConfig.cs
@@ -6,11 +6,12 @@ namespace TinyHealthCheck.Models
     {
         /// <summary>
         /// The hostname that will be listened on. 'localhost' by default, typically '*' is desired unless you know the hostname ahead of time.
+        /// If running inside a docker container, * or + may need to be used instead of 'localhost'.
         /// </summary>
         public string Hostname { get; set; } = "localhost";
 
         /// <summary>
-        /// Port that this health check will be served on
+        /// Port that this health check will be served on.
         /// </summary>
         public int Port { get; set; } = 8080;
 

--- a/TinyHealthCheck/TinyHealthCheck.csproj
+++ b/TinyHealthCheck/TinyHealthCheck.csproj
@@ -17,9 +17,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
-    <PackageReference Include="System.Text.Json" Version="6.0.4" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
+    <PackageReference Include="System.Text.Json" Version="7.0.3" />
   </ItemGroup>
 
 </Project>

--- a/TinyHealthCheck/TinyHealthCheck.csproj
+++ b/TinyHealthCheck/TinyHealthCheck.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <PackageProjectUrl>https://github.com/bruceharrison1984/TinyHealthCheck</PackageProjectUrl>
     <RepositoryUrl>https://github.com/bruceharrison1984/TinyHealthCheck</RepositoryUrl>
     <RepositoryType>git</RepositoryType>

--- a/TinyHealthCheck/TinyHealthCheck.csproj
+++ b/TinyHealthCheck/TinyHealthCheck.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <PackageProjectUrl>https://github.com/bruceharrison1984/TinyHealthCheck</PackageProjectUrl>
     <RepositoryUrl>https://github.com/bruceharrison1984/TinyHealthCheck</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
@@ -13,6 +13,7 @@
       Dead simple HTTP health checks without the MVC framework.
     </Description>
 	<PackageLicenseExpression>MIT</PackageLicenseExpression>
+	<LangVersion>11</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
# Motivations
Maintenance 

# Modifications
- Update the tests projects to .NET 7
- Update `TinyHealthCheck` to .NET Standard 2.1
- Update to C# 11 lang
- Update various packages to latest
- Add notes about using `*` or `+` as the health check hostname instead of `localhost`, in .NET 7 for some reason `localhost` breaks on the HttpListener if you're running your app inside a docker container (quite frankly too lazy to research into why, but this is the suggested fix according to stock overflow https://stackoverflow.com/questions/75961828/c-sharp-net-core-7-http-listener-app-wrapped-in-docker-cannot-be-reached-from)

# Finally
Thank you for this library, this was *exactly* what I needed for a console application specifically using a generic host instead of a web host but still hosting it on a k8s cluster