### PR TITLE
Add LogLevel to HealthCheckConfig for configurable logging levels for a Health Check

### DIFF
--- a/TinyHealthCheck/HealthCheckService.cs
+++ b/TinyHealthCheck/HealthCheckService.cs
@@ -36,7 +36,7 @@ namespace TinyHealthCheck
                 _listener.Prefixes.Add($"http://{_config.Hostname}:{_config.Port}/");
                 _listener.Start();
 
-                _logger.LogInformation($"TinyHealthCheck<{typeof(T).Name}> started on port '{_config.Port}'");
+                _logger.Log(_config.LogLevel, $"TinyHealthCheck<{typeof(T).Name}> started on port '{_config.Port}'");
 
                 var cancelTask = Task.Delay(Timeout.Infinite, cancellationToken);
                 while (!cancellationToken.IsCancellationRequested)
@@ -63,7 +63,7 @@ namespace TinyHealthCheck
         {
             var request = client.Request;
 
-            _logger.LogInformation($"TinyHealthCheck received a request from {request.RemoteEndPoint}");
+            _logger.Log(_config.LogLevel, $"TinyHealthCheck received a request from {request.RemoteEndPoint}");
 
             using (var response = client.Response)
             {

--- a/TinyHealthCheck/HealthCheckService.cs
+++ b/TinyHealthCheck/HealthCheckService.cs
@@ -53,7 +53,7 @@ namespace TinyHealthCheck
             }
             catch (Exception e)
             {
-                _logger.LogError(e, "TinyHealthCheck had an exception!");
+                _logger.LogError(e, "TinyHealthCheck<{TypeName}> encountered an exception!", _typeName);
             }
         }
 

--- a/TinyHealthCheck/HealthCheckService.cs
+++ b/TinyHealthCheck/HealthCheckService.cs
@@ -16,6 +16,7 @@ namespace TinyHealthCheck
         private readonly TinyHealthCheckConfig _config;
         private readonly T _healthCheck;
         private readonly HttpListener _listener = new HttpListener();
+        
         private readonly string _typeName;
 
         public HealthCheckService(ILogger<HealthCheckService<T>> logger, T healthCheck, TinyHealthCheckConfig config)

--- a/TinyHealthCheck/HealthCheckService.cs
+++ b/TinyHealthCheck/HealthCheckService.cs
@@ -16,12 +16,15 @@ namespace TinyHealthCheck
         private readonly TinyHealthCheckConfig _config;
         private readonly T _healthCheck;
         private readonly HttpListener _listener = new HttpListener();
+        private readonly string _typeName;
 
         public HealthCheckService(ILogger<HealthCheckService<T>> logger, T healthCheck, TinyHealthCheckConfig config)
         {
             _logger = logger;
             _config = config ?? throw new ArgumentNullException(nameof(config));
             _healthCheck = healthCheck;
+            
+            _typeName = typeof(T).Name;
         }
 
         /// <summary>
@@ -36,7 +39,7 @@ namespace TinyHealthCheck
                 _listener.Prefixes.Add($"http://{_config.Hostname}:{_config.Port}/");
                 _listener.Start();
 
-                _logger.Log(_config.LogLevel, $"TinyHealthCheck<{typeof(T).Name}> started on port '{_config.Port}'");
+                _logger.Log(_config.LogLevel, "TinyHealthCheck<{TypeName}> started on port {Port}", _typeName, _config.Port);
 
                 var cancelTask = Task.Delay(Timeout.Infinite, cancellationToken);
                 while (!cancellationToken.IsCancellationRequested)
@@ -62,8 +65,8 @@ namespace TinyHealthCheck
         private async Task ProcessHealthCheck(HttpListenerContext client, CancellationToken cancellationToken)
         {
             var request = client.Request;
-
-            _logger.Log(_config.LogLevel, $"TinyHealthCheck received a request from {request.RemoteEndPoint}");
+            
+            _logger.Log(_config.LogLevel, "TinyHealthCheck<{TypeName}> received a request from {RequestEndpoint}", _typeName, request.RemoteEndPoint);
 
             using (var response = client.Response)
             {

--- a/TinyHealthCheck/Models/TinyHealthCheckConfig.cs
+++ b/TinyHealthCheck/Models/TinyHealthCheckConfig.cs
@@ -1,4 +1,4 @@
-﻿using System.Text;
+﻿using Microsoft.Extensions.Logging;
 
 namespace TinyHealthCheck.Models
 {
@@ -19,5 +19,10 @@ namespace TinyHealthCheck.Models
         /// The url path that the health check will be accessible on.
         /// </summary>
         public string UrlPath { get; set; } = "/healthz";
+
+        /// <summary>
+        /// The logging level of the health check.
+        /// </summary>
+        public LogLevel LogLevel = LogLevel.Information;
     }
 }


### PR DESCRIPTION
# Motivations
Using TinyHealthCheck in a kubernetes environment the health check could be hit every few seconds which results in quite a lot of unnecessary logging coming from TinyHealthCheck

This is filterable thanks to libraries like Serilog, but having the log levels be 1) structured and 2) adjustable log-level wise would be pretty handy

# Modifications
- Add a `LogLevel` option to `TinyHealthCheckConfig` and default it to information
- Switch to generic `_logger.Log`, pass in the configured log level, and move to structured logging